### PR TITLE
Improvements

### DIFF
--- a/esi.gemspec
+++ b/esi.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "oauth2", "~> 1.4"
   spec.add_dependency "addressable", "~> 2.3"
-  spec.add_dependency "recursive-open-struct", "~> 1"
   spec.add_dependency "activesupport"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/esi/access_token.rb
+++ b/lib/esi/access_token.rb
@@ -1,5 +1,7 @@
 module Esi
   class AccessToken < OAuth2::AccessToken
+    EXPIRES_MARGIN = 30.seconds
+
     def initialize(*args)
       if args[0].is_a?(OAuth2::AccessToken)
         token = args[0]
@@ -12,6 +14,10 @@ module Esi
 
     def verify
       Esi::Response.new(get("/oauth/verify"))
+    end
+
+    def expired?
+      expires? && (expires_at < EXPIRES_MARGIN.ago.to_i)
     end
   end
 end

--- a/lib/esi/calls.rb
+++ b/lib/esi/calls.rb
@@ -34,12 +34,8 @@ module Esi
 
       attr_accessor :path, :params
 
-      def name
-        @name ||= self.class.name.remove('Esi::Calls::').underscore.to_sym
-      end
-
       def cache_key
-        @cache_key ||= ActiveSupport::Cache.expand_cache_key([name, params].flatten, :esi)
+        @cache_key ||= ActiveSupport::Cache.expand_cache_key([path, params].flatten, :esi)
       end
 
       def method

--- a/lib/esi/calls.rb
+++ b/lib/esi/calls.rb
@@ -40,7 +40,7 @@ module Esi
 
       def cache_key
         @cache_key ||= begin
-          cache_args = [CACHE_NAMESPACE, path.gsub(%r[^\/], ''), params.sort].flatten
+          cache_args = [CACHE_NAMESPACE, path.gsub(%r{^\/}, ''), params.sort].flatten
           ActiveSupport::Cache.expand_cache_key(cache_args)
         end
       end

--- a/lib/esi/calls.rb
+++ b/lib/esi/calls.rb
@@ -31,13 +31,18 @@ module Esi
     end
 
     class Base
+      CACHE_NAMESPACE = 'esi'
+
       class_attribute :scope
       class_attribute :cache_duration
 
       attr_accessor :path, :params
 
       def cache_key
-        @cache_key ||= ActiveSupport::Cache.expand_cache_key([:esi, path[1..-1], params.sort].flatten)
+        @cache_key ||= begin
+          cache_args = [CACHE_NAMESPACE, path.gsub(/^\//, ''), params.sort].flatten
+          ActiveSupport::Cache.expand_cache_key(cache_args)
+        end
       end
 
       def method

--- a/lib/esi/calls.rb
+++ b/lib/esi/calls.rb
@@ -37,7 +37,7 @@ module Esi
       attr_accessor :path, :params
 
       def cache_key
-        @cache_key ||= ActiveSupport::Cache.expand_cache_key([path, params].flatten, :esi)
+        @cache_key ||= ActiveSupport::Cache.expand_cache_key([:esi, path[1..-1], params.sort].flatten)
       end
 
       def method

--- a/lib/esi/calls.rb
+++ b/lib/esi/calls.rb
@@ -40,7 +40,7 @@ module Esi
 
       def cache_key
         @cache_key ||= begin
-          cache_args = [CACHE_NAMESPACE, path.gsub(/^\//, ''), params.sort].flatten
+          cache_args = [CACHE_NAMESPACE, path.gsub(%r[^\/], ''), params.sort].flatten
           ActiveSupport::Cache.expand_cache_key(cache_args)
         end
       end

--- a/lib/esi/o_auth.rb
+++ b/lib/esi/o_auth.rb
@@ -5,7 +5,7 @@ module Esi
     extend Forwardable
 
     attr_reader :access_token, :refresh_token, :expires_at
-    def_delegators :token, :get, :post, :delete, :patch, :put
+    def_delegators :token, :request, :get, :post, :delete, :patch, :put
 
     class << self
       def authorize_url(redirect_uri:, scopes: nil)
@@ -36,10 +36,6 @@ module Esi
       @callback = callback if callback
     end
 
-    def request(*args)
-      token.request(*args)
-    end
-
     private
 
     def token
@@ -50,8 +46,6 @@ module Esi
     end
 
     def refresh_access_token
-      Esi.logger.debug "Refreshing access token"
-
       ActiveSupport::Notifications.instrument('esi.oauth.refresh_token') do
         @token = @token.refresh!
         @access_token = @token.token

--- a/lib/esi/o_auth.rb
+++ b/lib/esi/o_auth.rb
@@ -3,7 +3,7 @@ module Esi
     extend Forwardable
 
     attr_reader :access_token, :refresh_token, :expires_at
-    def_delegators :token, :request, :get, :post, :delete, :patch, :put
+    def_delegators :token, :get, :post, :delete, :patch, :put
 
     class << self
       def authorize_url(redirect_uri:, scopes: nil)
@@ -36,6 +36,10 @@ module Esi
       @callback = callback if callback
     end
 
+    def request(*args)
+      token.request(*args)
+    end
+
     private
 
     def token
@@ -47,6 +51,8 @@ module Esi
     end
 
     def refresh_access_token
+      Esi.logger.debug "Refreshing access token"
+
       ActiveSupport::Notifications.instrument('esi.oauth.refresh_token') do
         @token = @token.refresh!
         @access_token = @token.token

--- a/lib/esi/response.rb
+++ b/lib/esi/response.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Esi
   class Response
     extend Forwardable

--- a/lib/esi/version.rb
+++ b/lib/esi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Esi
-  VERSION = "0.4.5"
+  VERSION = '0.4.1'
 end

--- a/lib/esi/version.rb
+++ b/lib/esi/version.rb
@@ -1,3 +1,3 @@
 module Esi
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end

--- a/lib/esi/version.rb
+++ b/lib/esi/version.rb
@@ -1,3 +1,3 @@
 module Esi
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
 end

--- a/lib/esi/version.rb
+++ b/lib/esi/version.rb
@@ -1,3 +1,3 @@
 module Esi
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/lib/esi/version.rb
+++ b/lib/esi/version.rb
@@ -1,3 +1,3 @@
 module Esi
-  VERSION = "0.4.1"
+  VERSION = "0.4.3"
 end

--- a/test/call_base_test.rb
+++ b/test/call_base_test.rb
@@ -4,16 +4,13 @@ require 'test_helper'
 
 Esi::Calls::MockCall = Class.new(Esi::Calls::Base) do
   def initialize
-    self.params = { id: 1234 }
+    self.path = '/mock_call/1234'
+    self.params = { p2: 'val2', p1: 'val1' }
   end
 end
 
 class EsiCallBaseTest < EsiTest
-  def test_instance_name
-    assert_equal :mock_call, Esi::Calls::MockCall.new.name
-  end
-
   def test_cache_key
-    assert_equal 'esi/mock_call/id/1234', Esi::Calls::MockCall.new.cache_key
+    assert_equal 'esi/mock_call/1234/p1/val1/p2/val2', Esi::Calls::MockCall.new.cache_key
   end
 end


### PR DESCRIPTION
* Refresh token 30 seconds before to avoid some issues
* Remove `RecursiveOpenStruct` because the `object_class` option in `JSON` handles this
* Fix cache key which wasn't unique when requesting same endpoint with a different id